### PR TITLE
FontService: fix potential NPE and handle disabled packages properly

### DIFF
--- a/services/core/java/com/android/server/FontService.java
+++ b/services/core/java/com/android/server/FontService.java
@@ -142,8 +142,10 @@ public class FontService extends IFontService.Stub {
                         synchronized (mFontMap) {
                             processFontPackage(packageName);
                         }
+                        break;
                     }
-                    break;
+                    // Fall through to MESSAGE_PACKAGE_REMOVED if the package
+                    // is not a font provider, in case it needs cleanup
                 case MESSAGE_PACKAGE_REMOVED:
                     packageName = (String) msg.obj;
                     boolean hadFonts = mFontMap.containsKey(packageName);
@@ -378,6 +380,7 @@ public class FontService extends IFontService.Stub {
 
     private boolean isPackageFontProvider(String packageName) {
         Context appContext = getAppContext(packageName);
+        if (appContext == null) return false;
         int id = appContext.getResources().getIdentifier(FONT_IDENTIFIER,
                 "bool",
                 appContext.getPackageName());


### PR DESCRIPTION
This was noticed when trying to use apps that can "freeze" (disable) other apps
and "unfreeze" (enable) them when needed.

On "unfreezing", it seems that the FontService will try to determine if
the new package is a font provider, while the app is still frozen and
will result in a NPE in FontService. This happened when I try to use the
Island app (with Greenify integration) on the latest build of OmniROM.

This patch simply returns false in `isPackageFontProvider()` when package is not found,
and falls through to the REMOVE case if the function is false, since packages that are
disabled cannot be used as a system-wide font provider anyway.

Change-Id: Idf1e44ae72a67bbd433959f30b6f96cb42243036

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>